### PR TITLE
Add new consumer configuration to improve memory usage

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -53,6 +53,7 @@ class Consumer
         $topicConf->set('auto.offset.reset', 'smallest');
 
         $conf = new \RdKafka\Conf();
+        $conf->set('queued.max.messages.kbytes', '10000');
         $conf->set('enable.auto.commit', 'false');
         $conf->set('compression.codec', 'gzip');
         $conf->set('max.poll.interval.ms', '86400000');


### PR DESCRIPTION
Adding new config `queued.max.messages.kbytes` with value 10Mb
to try to improve the memory usage, because the config default setting is 1Gb
so when there are too many messages to consume the memory consumption goes a lot.