### PR TITLE
Add support to Laravel 7.x, 8.x. Monolog 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "type": "project",
   "require": {
     "php": "~7.1",
-    "monolog/monolog": "^1.24",
+    "monolog/monolog": "^1.24 || ^2.1",
     "illuminate/console": "5.* || ^7.0 || ^8.0",
     "ext-rdkafka": "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": "~7.1",
     "monolog/monolog": "^1.24",
-    "illuminate/console": "5.*",
+    "illuminate/console": "5.* || ^7.0 || ^8.0",
     "ext-rdkafka": "*"
   },
   "require-dev": {


### PR DESCRIPTION
I'll start to use with new projects. I got this problem

```
 Problem 1
     - Conclusion: remove laravel/framework v7.28.1
     - Installation request for arquivei/php-kafka-consumer 2.2 -> satisfiable by arquivei/php-kafka-consumer[2.2.0].
     - Conclusion: don't install laravel/framework v7.28.1
     - Conclusion: don't install laravel/framework v7.28.0
     - arquivei/php-kafka-consumer 2.2.0 requires illuminate/console 5.* -> satisfiable by laravel/framework[5.7.x-dev, 5.8.x-dev], illuminate/console[5.0.x-dev, 5.1.x-dev, 5.2.x-dev, 5.3.x-dev, 5.4.x-dev, 5.5.x-dev, 5.6.x-dev, 5.7.17, 5.7.18, 5.7.19, 5.7.x-dev, 5.8.x-dev, v5.0.0, v5.0.22, v5.0.25, v5.0.26, v5.0.28, v5.0.33, v5.0.4, v5.1.1, v5.1.13, v5.1.16, v5.1.2, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.41, v5.1.6, v5.1.8, v5.2.0, v5.2.19, v5.2.21, v5.2.24, v5.2.25, v5.2.26, v5.2.27, v5.2.28, v5.2.31, v5.2.32, v5.2.37, v5.2.43, v5.2.45, v5.2.6, v5.2.7, v5.3.0, v5.3.16, v5.3.23, v5.3.4, v5.4.0, v5.4.13, v5.4.17, v5.4.19, v5.4.27, v5.4.36, v5.4.9, v5.5.0, v5.5.16, v5.5.17, v5.5.2, v5.5.28, v5.5.33, v5.5.34, v5.5.35, v5.5.36, v5.5.37, v5.5.39, v5.5.40, v5.5.41, v5.5.43, v5.5.44, v5.6.0, v5.6.1, v5.6.10, v5.6.11, v5.6.12, v5.6.13, v5.6.14, v5.6.15, v5.6.16, v5.6.17, v5.6.19, v5.6.2, v5.6.20, v5.6.21, v5.6.22, v5.6.23, v5.6.24, v5.6.26, v5.6.27, v5.6.28, v5.6.29, v5.6.3, v5.6.30, v5.6.31, v5.6.32, v5.6.33, v5.6.34, v5.6.35, v5.6.36, v5.6.37, v5.6.38, v5.6.39, v5.6.4, v5.6.5, v5.6.6, v5.6.7, v5.6.8, v5.6.9, v5.7.0, v5.7.1, v5.7.10, v5.7.11, v5.7.15, v5.7.2, v5.7.20, v5.7.21, v5.7.22, v5.7.23, v5.7.26, v5.7.27, v5.7.28, v5.7.3, v5.7.4, v5.7.5, v5.7.6, v5.7.7, v5.7.8, v5.7.9, v5.8.0, v5.8.11, v5.8.12, v5.8.14, v5.8.15, v5.8.17, v5.8.18, v5.8.19, v5.8.2, v5.8.20, v5.8.22, v5.8.24, v5.8.27, v5.8.28, v5.8.29, v5.8.3, v5.8.30, v5.8.31, v5.8.32, v5.8.33, v5.8.34, v5.8.35, v5.8.36, v5.8.4, v5.8.8, v5.8.9].
     - Can only install one of: laravel/framework[7.x-dev, 5.7.x-dev].
     - Can only install one of: laravel/framework[7.x-dev, 5.8.x-dev].
     - don't install illuminate/console 5.7.17|don't install laravel/framework 7.x-dev
     - don't install illuminate/console 5.7.18|don't install laravel/framework 7.x-dev
     - don't install illuminate/console 5.7.19|don't install laravel/framework 7.x-dev
     - don't install illuminate/console 5.7.x-dev|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.0|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.1|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.10|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.11|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.15|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.2|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.20|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.21|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.22|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.23|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.26|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.27|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.28|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.3|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.4|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.5|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.6|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.7|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.8|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.7.9|don't install laravel/framework 7.x-dev
     - don't install illuminate/console 5.8.x-dev|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.0|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.11|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.12|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.14|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.15|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.17|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.18|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.19|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.2|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.20|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.22|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.24|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.27|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.28|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.29|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.3|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.30|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.31|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.32|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.33|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.34|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.35|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.36|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.4|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.8|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.8.9|don't install laravel/framework 7.x-dev
     - don't install illuminate/console 5.0.x-dev|don't install laravel/framework 7.x-dev
     - don't install illuminate/console 5.1.x-dev|don't install laravel/framework 7.x-dev
     - don't install illuminate/console 5.2.x-dev|don't install laravel/framework 7.x-dev
     - don't install illuminate/console 5.3.x-dev|don't install laravel/framework 7.x-dev
     - don't install illuminate/console 5.4.x-dev|don't install laravel/framework 7.x-dev
     - don't install illuminate/console 5.5.x-dev|don't install laravel/framework 7.x-dev
     - don't install illuminate/console 5.6.x-dev|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.0.0|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.0.22|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.0.25|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.0.26|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.0.28|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.0.33|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.0.4|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.1.1|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.1.13|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.1.16|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.1.2|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.1.20|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.1.22|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.1.25|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.1.28|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.1.30|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.1.31|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.1.41|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.1.6|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.1.8|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.0|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.19|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.21|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.24|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.25|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.26|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.27|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.28|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.31|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.32|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.37|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.43|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.45|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.6|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.2.7|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.3.0|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.3.16|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.3.23|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.3.4|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.4.0|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.4.13|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.4.17|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.4.19|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.4.27|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.4.36|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.4.9|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.0|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.16|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.17|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.2|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.28|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.33|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.34|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.35|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.36|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.37|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.39|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.40|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.41|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.43|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.5.44|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.0|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.1|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.10|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.11|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.12|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.13|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.14|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.15|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.16|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.17|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.19|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.2|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.20|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.21|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.22|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.23|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.24|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.26|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.27|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.28|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.29|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.3|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.30|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.31|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.32|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.33|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.34|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.35|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.36|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.37|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.38|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.39|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.4|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.5|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.6|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.7|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.8|don't install laravel/framework 7.x-dev
     - don't install illuminate/console v5.6.9|don't install laravel/framework 7.x-dev
     - Installation request for laravel/framework ^7.28 -> satisfiable by laravel/framework[7.x-dev, v7.28.0, v7.28.1].
 
```