### PR TITLE
Adds badges and credit to wait-for-it.sh

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # php-kafka-consumer
 
+[![Latest Stable Version](https://poser.pugx.org/arquivei/php-kafka-consumer/v/stable)](https://packagist.org/packages/arquivei/php-kafka-consumer) [![Total Downloads](https://poser.pugx.org/arquivei/php-kafka-consumer/downloads)](https://packagist.org/packages/arquivei/php-kafka-consumer) ![Tests](https://github.com/arquivei/php-kafka-consumer/workflows/Test/badge.svg) ![Dependency coverage](https://github.com/arquivei/php-kafka-consumer/workflows/Version%20test/badge.svg)
+
 An Apache Kafka consumer in PHP. Subscribe to topics and define callbacks to handle the messages.
 
 ## Requirements

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,4 +1,29 @@
 #!/usr/bin/env bash
+
+# MIT License
+
+# Copyright (c) 2016 Giles Hall
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Script copied from https://github.com/vishnubob/wait-for-it
+
 # Use this script to test if a given TCP host/port are available
 
 WAITFORIT_cmdname=${0##*/}


### PR DESCRIPTION
Adds badges for the build status and the number of downloads and adds proper credit to the creators of wait-for-it.sh as stated that we should've done a while ago in #24.

Closes #24 