### PR TITLE
Improve consumer API

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -11,13 +11,10 @@ use RdKafka\Conf;
 use RdKafka\KafkaConsumer;
 use RdKafka\Message;
 use RdKafka\Producer;
-use RdKafka\TopicConf;
 use Throwable;
 
 class Consumer
 {
-    private const MAX_COMMIT_RETRIES = 6;
-
     private const IGNORABLE_CONSUME_ERRORS = [
         RD_KAFKA_RESP_ERR__PARTITION_EOF,
         RD_KAFKA_RESP_ERR__TIMED_OUT,
@@ -73,7 +70,7 @@ class Consumer
         $conf->set('bootstrap.servers', $this->config->getBroker());
         $conf->set('security.protocol', $this->config->getSecurityProtocol());
 
-        if ($this->config->isPlainText()) {
+        if ($this->config->isPlainText() && $this->config->getSasl() !== null) {
             $conf->set('sasl.username', $this->config->getSasl()->getUsername());
             $conf->set('sasl.password', $this->config->getSasl()->getPassword());
             $conf->set('sasl.mechanisms', $this->config->getSasl()->getMechanisms());

--- a/src/ConsumerBuilder.php
+++ b/src/ConsumerBuilder.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kafka\Consumer;
+
+use Closure;
+use InvalidArgumentException;
+use Kafka\Consumer\Entities\Config;
+use Kafka\Consumer\Entities\Config\Sasl;
+use Kafka\Consumer\MessageHandler\CallableConsumer;
+
+class ConsumerBuilder
+{
+    private $topics;
+    private $commit;
+    private $groupId;
+    private $handler;
+    private $maxMessages;
+    private $maxCommitRetries;
+    private $brokers;
+    private $middlewares;
+    private $saslConfig = null;
+    private $dlq;
+    private $securityProtocol;
+
+    private function __construct(string $brokers, string $groupId, array $topics)
+    {
+        foreach ($topics as $topic) {
+            if (!is_string($topic)) {
+                throw new InvalidArgumentException('The topic name should be a string value');
+            }
+        }
+
+        $this->brokers = $brokers;
+        $this->groupId = $groupId;
+        $this->topics = $topics;
+
+        $this->commit = 1;
+        $this->handler = function () {
+        };
+        $this->maxMessages = -1;
+        $this->maxCommitRetries = 6;
+        $this->middlewares = [];
+        $this->securityProtocol = 'PLAINTEXT';
+    }
+
+    public static function create(string $brokers, $groupId, array $topics): self
+    {
+        return new ConsumerBuilder($brokers, $groupId, $topics);
+    }
+
+    public function withCommitBatchSize(int $size): self
+    {
+        $this->commit = $size;
+        return $this;
+    }
+
+    /**
+     * The function that will handle the incoming messages
+     *
+     * @param callable(mixed $message): void $handler
+     */
+    public function withHandler(callable $handler): self
+    {
+        $this->handler = Closure::fromCallable($handler);
+        return $this;
+    }
+
+    public function withMaxMessages(int $maxMessages): self
+    {
+        $this->maxMessages = $maxMessages;
+        return $this;
+    }
+
+    public function withMaxCommitRetries(int $maxCommitRetries): self
+    {
+        $this->maxCommitRetries = $maxCommitRetries;
+        return $this;
+    }
+
+    public function withDlq(?string $dlqTopic = null): self
+    {
+        if (null === $dlqTopic) {
+            $dlqTopic = $this->topics[0] . '-dlq';
+        }
+
+        $this->dlq = $dlqTopic;
+
+        return $this;
+    }
+
+    public function withSasl(Sasl $saslConfig): self
+    {
+        $this->saslConfig = $saslConfig;
+        return $this;
+    }
+
+    /**
+     * The middlewares get executed in the order they are defined.
+     *
+     * The middleware is a callable in which the first argument is the message itself and the second is the next handler
+     *
+     * @param callable(mixed, callable): void $middleware
+     * @return $this
+     */
+    public function withMiddleware(callable $middleware): self
+    {
+        $this->middlewares[] = $middleware;
+        return $this;
+    }
+
+    public function withSecurityProtocol(string $securityProtocol): self
+    {
+        $this->securityProtocol = $securityProtocol;
+        return $this;
+    }
+
+    public function build(): Consumer
+    {
+        $config = new Config(
+            $this->saslConfig,
+            $this->topics,
+            $this->brokers,
+            $this->commit,
+            $this->groupId,
+            new CallableConsumer($this->handler, $this->middlewares),
+            $this->securityProtocol,
+            $this->dlq,
+            $this->maxMessages,
+            $this->maxCommitRetries
+        );
+
+        return new Consumer(
+            $config
+        );
+    }
+}

--- a/src/Entities/Config.php
+++ b/src/Entities/Config.php
@@ -19,7 +19,7 @@ class Config
     private $maxCommitRetries;
 
     public function __construct(
-        Sasl $sasl,
+        ?Sasl $sasl,
         array $topics,
         string $broker,
         int $commit,
@@ -42,7 +42,7 @@ class Config
         $this->maxCommitRetries = $maxCommitRetries;
     }
 
-    public function getSasl(): Sasl
+    public function getSasl(): ?Sasl
     {
         return $this->sasl;
     }

--- a/src/MessageHandler/CallableConsumer.php
+++ b/src/MessageHandler/CallableConsumer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kafka\Consumer\MessageHandler;
+
+use Closure;
+use Kafka\Consumer\Contracts\Consumer;
+
+class CallableConsumer extends Consumer
+{
+    private $handler;
+    private $middlewares;
+
+    public function __construct(callable $handler, array $middlewares)
+    {
+        $this->handler = Closure::fromCallable($handler);
+        $this->middlewares = array_map([$this, 'wrapMiddleware'], $middlewares);
+        $this->middlewares[] = $this->wrapMiddleware(function ($message, callable $next) {
+            $next($message);
+        });
+    }
+
+    public function handle(string $message): void
+    {
+        $middlewares = array_reverse($this->middlewares);
+        $handler = array_shift($middlewares)($this->handler);
+
+        foreach ($middlewares as $middleware) {
+            $handler = $middleware($handler);
+        }
+
+        $handler($message);
+    }
+
+    private function wrapMiddleware(callable $middleware): callable
+    {
+        return function (callable $handler) use ($middleware) {
+            return function ($message) use ($handler, $middleware) {
+                $middleware($message, $handler);
+            };
+        };
+    }
+}

--- a/tests/Integration/TestConsumer.php
+++ b/tests/Integration/TestConsumer.php
@@ -2,9 +2,7 @@
 
 namespace Kafka\Consumer\Tests\Integration;
 
-use Kafka\Consumer\Contracts\Consumer;
-
-class TestConsumer extends Consumer
+class TestConsumer
 {
     public const RESPONSE_OK = 'response_ok';
     public const RESPONSE_ERROR = 'response_error';
@@ -20,7 +18,7 @@ class TestConsumer extends Consumer
         self::$callCounter = 0;
     }
 
-    public function handle(string $message): void
+    public function __invoke(string $message): void
     {
         if (!empty(self::$responses)) {
             $responseDirective = self::$responses[self::$callCounter++];

--- a/tests/Unit/Commit/MessageHandler/CallableConsumerTest.php
+++ b/tests/Unit/Commit/MessageHandler/CallableConsumerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kafka\Consumer\Tests\Unit\Commit\MessageHandler;
+
+use Kafka\Consumer\MessageHandler\CallableConsumer;
+use Monolog\Test\TestCase;
+use stdClass;
+
+class CallableConsumerTest extends TestCase
+{
+    public function testShouldDecodeMessages(): void
+    {
+        $rawMessage = <<<JSON
+{
+    "foo": "bar"
+}
+JSON;
+
+        $consumer = new CallableConsumer([$this, 'handleMessage'], [
+            function (string $message, callable $next): void {
+                $decoded = json_decode($message);
+                $next($decoded);
+            },
+            function (stdClass $message, callable $next): void {
+                $decoded = (array) $message;
+                $next($decoded);
+            }
+        ]);
+
+        $consumer->handle($rawMessage);
+    }
+
+    public function handleMessage(array $data): void
+    {
+        $this->assertEquals([
+            'foo' => 'bar'
+        ], $data);
+    }
+}


### PR DESCRIPTION
 * Add a ConsumerBuilder class to ease the process of instantiating the
 Consumer class.

 * Simplify the handling of messages: Remove the need to inherit the
 abstract Consumer class and allow the user to provide any callable to
 handle the kafka messages.

 * Add the concept of message decoding in order to enable the user to
 create reusable decoder (e.g. json or kafka decoder). The return of the
 decoder is the value passed to the message handler callable.

All these improvements were extracted from the [php-kafka project](https://github.com/arquivei/php-kafka/releases/tag/v0.1-alpha), an attempt to build a more generic and developer-friendly php kafka client. 

This PR seeks to incorporate some of the changes proposed by [php-kafka](https://github.com/arquivei/php-kafka) while keeping total compatibility with the current API. This allows us to actually test this new API and refine it until we achieve a final API for a future major release.