### PR TITLE
Add retry

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -158,7 +158,7 @@ If you want to contribute, there are a few utilities that will help.
 
 First create a container:
 
-`docker-composer up -d --build`
+`docker-compose up -d --build`
 
 If you have make, you can use pre defined commands in the Makefile
 

--- a/src/Retry/Retryable.php
+++ b/src/Retry/Retryable.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Kafka\Consumer\Retry;
+
+use Kafka\Consumer\Commit\Sleeper;
+use RdKafka\Exception;
+
+class Retryable
+{
+    private $sleeper;
+    private $maximumRetries;
+    private $retryableErrors;
+
+    public function __construct(Sleeper $sleeper, int $maximumRetries, array $retryableErrors)
+    {
+        $this->sleeper = $sleeper;
+        $this->maximumRetries = $maximumRetries;
+        $this->retryableErrors = $retryableErrors;
+    }
+
+    public function retry(
+        callable $function,
+        int $currentRetries = 0,
+        int $delayInSeconds = 1,
+        bool $exponentially = true
+    ) {
+        try {
+            $function();
+        } catch (Exception $exception) {
+            if (in_array($exception->getCode(), $this->retryableErrors) && $currentRetries < $this->maximumRetries) {
+                $this->sleeper->sleep((int)($delayInSeconds * 1e6));
+                $this->retry(
+                    $function,
+                    ++$currentRetries,
+                    $exponentially == true ? $delayInSeconds * 2 : $delayInSeconds
+                );
+                return;
+            }
+
+            throw $exception;
+        }
+    }
+}


### PR DESCRIPTION
A class has been added with all the retry logic that should be used in commit and message consumption.

Consumption starts to deal with timeout errors, retaining in the case of consumption timeout.