### PR TITLE
Fix internal retry rdkafka error.

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -19,10 +19,10 @@ class Consumer
     private const IGNORABLE_CONSUME_ERRORS = [
         RD_KAFKA_RESP_ERR__PARTITION_EOF,
         RD_KAFKA_RESP_ERR__TRANSPORT,
+        RD_KAFKA_RESP_ERR__TIMED_OUT
     ];
 
     private const TIMEOUT_ERRORS = [
-        RD_KAFKA_RESP_ERR__TIMED_OUT,
         RD_KAFKA_RESP_ERR_REQUEST_TIMED_OUT,
     ];
 


### PR DESCRIPTION
We made an adjustment to disregard the error RD_KAFKA_RESP_ERR__TIMED_OUT which is internal to the lib of rdkafka.
This error happens because we don't have a message to be consumed and the return is null. Only that the error is registered in rdkafka, which is not necessarily an error that we must consider.