### PR TITLE
Removes improper configs

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM joesantos386/laravel:php7.4-v1.5.2-4.0.4-8
+FROM joesantos386/laravel:8.0-v1.5.3-5.0.0-8
 
 RUN apk add libzip-dev
 


### PR DESCRIPTION
Some producer configs were being passed to the consumer and vice versa.
Such improper configs were causing some configuration warnings. This
commit fixes the configs and removes the problem causing the warnings.