### PR TITLE
Updates rdkafka to v1.6.1

### DIFF
--- a/.github/workflows/version-test.yml
+++ b/.github/workflows/version-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         php: [7.3, 7.4]
-        librdkafka: [v1.5.3]
+        librdkafka: [v1.6.1]
         extrdkafka: [3.0.5, 3.1.2, 4.0.4, 5.0.0]
         laravel: [6, 7, 8]
     steps:
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         php: ["8.0"]
-        librdkafka: [v1.5.3]
+        librdkafka: [v1.6.1]
         extrdkafka: [5.0.0]
         laravel: [6, 7, 8]
     steps:

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -39,7 +39,7 @@ services:
       context: .
       dockerfile: build/test/Dockerfile
       args:
-        TAG: 8.0-v1.5.3-5.0.0-8
+        TAG: 8.0-v1.6.1-5.0.0-8
         LARAVEL_VERSION: 8
     entrypoint: /application/php-kafka-consumer/start.sh
     networks:


### PR DESCRIPTION
The rdkafka library has been updated and now the v1.6.1 is the only
version supported. This commit updated the tests to ensure everything
works with the new version.