### PR TITLE
Add support for newer rdkafka versions

### DIFF
--- a/.github/workflows/version-test.yml
+++ b/.github/workflows/version-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         php: [7.3, 7.4]
         librdkafka: [v1.7.0]
-        extrdkafka: [3.0.5, 3.1.2, 4.0.4, 5.0.0]
+        extrdkafka: [3.0.5, 3.1.2, 4.0.4, 5.0.2]
         laravel: [6, 7, 8]
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": "~7.2 || ~7.3 || ~7.4 || ~8.0",
     "monolog/monolog": "~1 || ~2",
     "illuminate/console": "~6 || ~7 || ~8",
-    "ext-rdkafka": "~3.0 || ~3.1 || ~4.0 || 5.0"
+    "ext-rdkafka": "~3.0 || ~3.1 || ~4.0 || ~5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~7 || ~8 || ~9"


### PR DESCRIPTION
The composer.json constraints would not make it possible to use the lib with new minor versions of rdkafka.