### PR TITLE
Adds support for monolog 3 where a record is no longer an array

### DIFF
--- a/src/Log/Logger.php
+++ b/src/Log/Logger.php
@@ -18,7 +18,10 @@ class Logger
         $this->logger = new \Monolog\Logger('PHP-KAFKA-CONSUMER-ERROR');
         $this->logger->pushHandler($handler);
         $this->logger->pushProcessor(function ($record) {
-            $record['datetime'] = $record['datetime']->format('c');
+            if (is_array($record)) {
+                $record['datetime'] = $record['datetime']->format('c');
+            }
+
             return $record;
         });
     }


### PR DESCRIPTION
From the docs:

> _Log records have been converted from an array to a [Monolog\LogRecord object](https://github.com/Seldaek/monolog/blob/main/src/Monolog/LogRecord.php) with public (and mostly readonly) properties. e.g. instead of doing $record['context'] use $record->context. In formatters or handlers if you rather need an array to work with you can use $record->toArray() to get back a Monolog 1/2 style record array. This will contain the enum values instead of enum cases in the level and level_name keys to be more backwards compatible and use simpler data types._

https://github.com/Seldaek/monolog/blob/main/UPGRADE.md#300
